### PR TITLE
Use configuration option for icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,6 @@ Move `anotify.py` to `~/.weechat/python/autoload/anotify.py`.
 - `sticky`: Set sticky notifications. (on/off*)
 - `sticky_away`: Set sticky notifications only when away. (on*/off)
 
+### Miscellaneous Settings
+
+- `icon`: Set icon to be used in notification bubble. (path or theme string, default=`/usr/share/pixmaps/weechat.xpm`)

--- a/anotify.py
+++ b/anotify.py
@@ -129,7 +129,6 @@ DISPATCH_TABLE = {
 
 
 STATE = {
-    'icon': None,
     'is_away': False
 }
 
@@ -404,7 +403,7 @@ def cb_process_message(
 def a_notify(notification, title, description, priority=pynotify.URGENCY_LOW):
     '''Returns whether notifications should be sticky.'''
     is_away = STATE['is_away']
-    icon = STATE['icon']
+    icon = weechat.config_get_plugin('icon')
     time_out = 5000
     if weechat.config_get_plugin('sticky') == 'on':
         time_out = 0
@@ -431,7 +430,6 @@ def main():
             weechat.config_set_plugin(option, value)
     # Initialize.
     name = "WeeChat"
-    icon = "/usr/share/pixmaps/weechat.xpm"
     notifications = [
         'Public',
         'Private',
@@ -444,7 +442,6 @@ def main():
         'DCC',
         'WeeChat'
     ]
-    STATE['icon'] = icon
     # Register hooks.
     weechat.hook_signal(
         'irc_server_connected',

--- a/anotify.py
+++ b/anotify.py
@@ -39,7 +39,7 @@ SCRIPT_DESC = 'Sends libnotify notifications upon events.'
 # -----------------------------------------------------------------------------
 # Settings
 # -----------------------------------------------------------------------------
-SETTINGS = {
+DEFAULT_SETTINGS = {
     'show_public_message': 'off',
     'show_private_message': 'on',
     'show_public_action_message': 'off',
@@ -426,7 +426,7 @@ def a_notify(notification, title, description, priority=pynotify.URGENCY_LOW):
 def main():
     '''Sets up WeeChat notifications.'''
     # Initialize options.
-    for option, value in SETTINGS.items():
+    for option, value in DEFAULT_SETTINGS.items():
         if not weechat.config_is_set_plugin(option):
             weechat.config_set_plugin(option, value)
     # Initialize.


### PR DESCRIPTION
Hi. Your code seems to have everything ready for icon configuration, but the value is never used... This PR should fix it.

Also... I could not but notice, that version of this [script hosted on Weechat scripts](https://weechat.org/scripts/source/anotify.py.html/) seems a little newer... (for example changelog, ...) is that intentional?